### PR TITLE
Detect content type from magic number of first chunk

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -18,6 +18,9 @@ ignore_missing_imports = True
 [mypy-editorconfig.*]
 ignore_missing_imports = True
 
+[mypy-magic.*]
+ignore_missing_imports = True
+
 [mypy-semver.*]
 ignore_missing_imports = True
 

--- a/dependencies.apt.txt
+++ b/dependencies.apt.txt
@@ -21,6 +21,7 @@ python3-jsonschema
 python3-editorconfig
 python3-lxml
 python3-packaging
+python3-magic
 squashfs-tools
 ssh-client
 jq

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ jsonschema
 editorconfig
 lxml
 packaging
+python-magic


### PR DESCRIPTION
Should fix #245

For some reason, tests.test_checker.TestExternalDataChecker finds 3 new versions instead of 2, even without my changes applied: See the latest CI job of this branch, which prints the found sources:

https://github.com/Alexander-Wilms/flatpak-external-data-checker/tree/investigate-test-test_checker_testexternaldatachecker